### PR TITLE
Make it compatible with Lua 5.1 and fix Lua version range in rockspec

### DIFF
--- a/iter-0.0.2-1.rockspec
+++ b/iter-0.0.2-1.rockspec
@@ -13,7 +13,7 @@ description = {
   license = "MIT/X11"
 }
 dependencies = {
-  "lua ~> 5.2"
+  "lua >= 5.1"
 }
 build = {
   type = "builtin",

--- a/test.lua
+++ b/test.lua
@@ -8,7 +8,7 @@ Expected: %s
 Got: %s]]
 
 local function expect(x, y, msg)
-  assert(x == y, string.format(MSG_TEMPLATE, msg or "", y, x))
+  assert(x == y, string.format(MSG_TEMPLATE, msg or "", y or "", x or ""))
   print(msg)
 end
 


### PR DESCRIPTION
I've verified that tests pass on Lua 5.1, 5.2, 5.3 and LuaJIT 2.1.0beta2.

Note: lua ~> 5.2 does *not* include Lua 5.3!