### PR TITLE
Add count

### DIFF
--- a/iter.lua
+++ b/iter.lua
@@ -434,4 +434,21 @@ local function find(predicate, next)
 end
 exports.find = find
 
+local function increment(number)
+  return number + 1
+end
+
+-- Count the number of values in the iterator.
+--
+-- Example:
+--
+--     local t = {1, 2, 3}
+--     local x = iter.ivalues(t)
+--     local n = iter.count(x)
+--     -- 3
+local function count(next)
+  return reduce(increment, 0, next)
+end
+exports.count = count
+
 return exports

--- a/test.lua
+++ b/test.lua
@@ -172,3 +172,9 @@ do
   expect(y[4], 4, "dedupe(iter) dedupes correctly")
   expect(y[5], 3, "dedupe(iter) only dedupes adjacent")
 end
+
+do
+  local x = iter.ivalues({1, 2, 3, 4, 5})
+  local n = iter.count(x)
+  expect(n, 5, "count(iter) counts the number of values")
+end


### PR DESCRIPTION
I noticed that there is no function for counting the number of values in the iterator. Instead, `#iter.collect(some_iterator)` has been used, at least in the documentation. I think that `count` is a valuable addition because it is a common iterative operation and because dropping the unnecessary table creation in `#iter.collect` improves performance a bit (my completely unscientific tests say ~2x).

Let me know if something is missing :)